### PR TITLE
Feat/layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import './globals.css';
 import Header from '@/components/layout/Header';
-import Footer from '@/components/layout/Footer';
 import BottomNav from '@/components/layout/BottomNav';
 
 const geistSans = localFont({
@@ -35,6 +34,7 @@ export default function RootLayout({
         <div>
           <Header />
           {children}
+
           <div className="block sm:hidden">
             <BottomNav />
           </div>

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -21,6 +21,12 @@ const BottomNav = () => {
         <span className="text-sm text-black font-bold">봉사 찾기</span>
       </Link>
 
+      {/* 게시글 리스트 페이지 이동 버튼 */}
+      <Link href="search-list" className="flex flex-col items-center hover:text-blue-600">
+        <span>💬</span>
+        <span className="text-sm text-black font-bold">채팅하기</span>
+      </Link>
+
       {/* 마이페이지 */}
       <Link href="my-page" className="flex flex-col items-center hover:text-blue-600">
         <span>👤</span>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,43 @@
 const Footer = () => {
   return (
-    <div>Footer</div>
-  )
-}
+    <footer className="bg-white py-8 border-t hidden sm:block">
+      {/* 푸터 컨텐츠 */}
+      <div className="max-w-content mx-auto flex justify-between text-sm text-gray-600 min-h-[100px]">
+        {/* 왼쪽 로고 */}
+        <div className="text-xl font-bold text-black">ON:SON</div>
 
-export default Footer
+        {/* 중앙 정보 */}
+        <div className="flex flex-row">
+          <div className="flex flex-col space-y-2 mr-12">
+            <div>
+              <span className="font-semibold">대표진</span> 김진실, 김문식, 서한솔, 이경민, 한다영
+            </div>
+            <div>
+              <span className="font-semibold">주소</span> 서울특별시 강남구 테헤란로 44길 8 12층
+            </div>
+            <div>
+              <span className="font-semibold">사업자등록번호</span> 783-86-01715
+            </div>
+          </div>
+
+          {/* 오른쪽 정보 */}
+          <div className="flex flex-col space-y-2 text-right">
+            <div>
+              <span className="font-semibold">EMAIL</span> 1j5p@onson.dev
+            </div>
+            <div>
+              <span className="font-semibold">TEL</span> 02-1522-8016
+            </div>
+            <div>
+              <span className="font-semibold">FAX</span> 02-1522-8016
+            </div>
+
+            <div className="text-gray-500 text-xs mt-4">© 2025 ONSON All Right Reserved.</div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,13 +1,19 @@
-import ProfileDropdawn from './ProfileDropdown';
+import Link from 'next/link';
+import RightSide from './header-right/RightSide';
 
 const Header = () => {
   return (
-    <div>
-      <header className="bg-white shadow-md p-4 flex justify-between items-center">
-        <div className="text-xl font-bold text-black">ON:SON</div>
-        <ProfileDropdawn />
-      </header>
-    </div>
+    <header className="flex justify-center bg-white shadow-md p-4">
+      <div className="max-w-content w-full flex justify-between items-center">
+        {/* 로고부분 */}
+        <Link href="/" className="text-xl font-bold text-black">
+          ON:SON
+        </Link>
+        <div className="hidden sm:block">
+          <RightSide />
+        </div>
+      </div>
+    </header>
   );
 };
 

--- a/src/components/layout/header-right/ProfileDropdown.tsx
+++ b/src/components/layout/header-right/ProfileDropdown.tsx
@@ -1,43 +1,41 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
-const ProfileDropdawn = () => {
+const ProfileDropdown = () => {
   const [isDropdown, setIsDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
 
-  const toggleDropdown = () => {
-    setIsDropdown(!isDropdown);
+  // 드롭다운을 열기위한 토글글
+  const toggleDropdown = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsDropdown((prev) => !prev);
   };
 
-  const closeDropdown = () => {
-    setIsDropdown(false);
-  };
-
+  // 비동기적인 드롭다운 닫기 처리
   useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (!target.closest('.profile-dropdown')) {
-        closeDropdown();
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsDropdown(false);
       }
     };
 
-    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('click', handleOutsideClick);
 
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('click', handleOutsideClick);
     };
   }, []);
 
   return (
-    <div className="relative w-10 h-10">
+    <div className="relative w-10 h-10" ref={dropdownRef}>
       <img
         src="https://via.placeholder.com/40"
         alt="Profile"
         className="w-10 h-10 rounded-full object-cover border border-gray-300 cursor-pointer"
         onClick={toggleDropdown}
       />
-
       {isDropdown && (
         <div className="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-10">
           <ul>
@@ -47,7 +45,12 @@ const ProfileDropdawn = () => {
             <li className="px-4 py-2 text-black hover:bg-gray-100 cursor-pointer">
               <Link href="/continue-chat">대화 이어가기</Link>
             </li>
-            <li className="px-4 py-2 hover:bg-gray-100 cursor-pointer text-red-500" onClick={closeDropdown}>
+            <li
+              className="px-4 py-2 hover:bg-gray-100 cursor-pointer text-red-500"
+              onClick={() => {
+                setIsDropdown(false);
+              }}
+            >
               <button>로그아웃</button>
             </li>
           </ul>
@@ -57,4 +60,4 @@ const ProfileDropdawn = () => {
   );
 };
 
-export default ProfileDropdawn;
+export default ProfileDropdown;

--- a/src/components/layout/header-right/RightSide.tsx
+++ b/src/components/layout/header-right/RightSide.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import ProfileDropdawn from './ProfileDropdown';
+
+const RightSide = () => {
+  return (
+    <div className="flex flex-row gap-4">
+      <Link
+        href="/login"
+        className="text-black  
+      border border-black rounded-full px-4 py-2 hover:bg-blue-200"
+      >
+        봉사요청
+      </Link>
+
+      <Link
+        href="/search-list"
+        className="text-black  
+      border border-black rounded-full px-4 py-2 hover:bg-blue-200"
+      >
+        봉사찾기
+      </Link>
+
+      <ProfileDropdawn />
+    </div>
+  );
+};
+
+export default RightSide;


### PR DESCRIPTION
두번째 시안에 맞춰서 헤더를 수정했고 드롭다운에서 버그가 좀 있어서 그 부분을 수정했습니다.
먼저 헤더 부분은 기존엔 모바일에서 프로필이 보이고 드롭다운이 보였지만 수정된 부분에선
프로필이 헤더부분에 보이지않고 GNB 부분에 채팅하기가 추가되었습니다.
아래 GNB에 있는 마이페이지에 차후 프로필 이미지를 넣어 로그인 된 사용자는 
마이페이지 버튼 부분에서 본인의 프로필 이미지가 보이도록 차후 변경할 예정입니다.
그리고 푸터에 관련된 코드를 작성하였으나 아직 데스크톱 부분은 본격적인 개발이 된 부분이 아니라서
적용 시키지 않았으니 이 점 확인하시면 될거 같습니다.